### PR TITLE
Fix inconsistent service metadata

### DIFF
--- a/services/crm-service/cmd/main.go
+++ b/services/crm-service/cmd/main.go
@@ -5,14 +5,13 @@ import (
 	"os"
 
 	"github.com/gin-gonic/gin"
-	"crm-service/utils"
 )
 
 func main() {
 	// Get port from environment or use default
 	port := os.Getenv("PORT")
 	if port == "" {
-		port = "8001"
+		port = "8002"
 	}
 
 	// Create Gin router
@@ -21,17 +20,17 @@ func main() {
 	// Health check endpoint
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"service": "fm-service",
+			"service": "crm-service",
 			"status":  "healthy",
 			"port":    port,
 		})
 	})
 
 	// Hello World endpoint
-	r.GET("/api/fm/hello", func(c *gin.Context) {
+	r.GET("/api/crm/hello", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"message": "Hello World from Financial Management Service!",
-			"service": "fm-service",
+			"message": "Hello World from Customer Relationship Management Service!",
+			"service": "crm-service",
 			"port":    port,
 		})
 	})
@@ -39,12 +38,11 @@ func main() {
 	// Root endpoint
 	r.GET("/", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"message": "Financial Management Service is running",
-			"service": "fm-service",
+			"message": "Customer Relationship Management Service is running",
+			"service": "crm-service",
 			"port":    port,
 		})
 	})
 
 	// Start server
-	r.Run(":" + port)
-}
+	r.Run(":" + port)}

--- a/services/hr-service/cmd/main.go
+++ b/services/hr-service/cmd/main.go
@@ -5,14 +5,13 @@ import (
 	"os"
 
 	"github.com/gin-gonic/gin"
-	"hr-service/utils" // Assuming utils package is in the same directory structure
 )
 
 func main() {
 	// Get port from environment or use default
 	port := os.Getenv("PORT")
 	if port == "" {
-		port = "8001"
+		port = "8003"
 	}
 
 	// Create Gin router
@@ -21,17 +20,17 @@ func main() {
 	// Health check endpoint
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"service": "fm-service",
+			"service": "hr-service",
 			"status":  "healthy",
 			"port":    port,
 		})
 	})
 
 	// Hello World endpoint
-	r.GET("/api/fm/hello", func(c *gin.Context) {
+	r.GET("/api/hr/hello", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"message": "Hello World from Financial Management Service!",
-			"service": "fm-service",
+			"message": "Hello World from Human Resources Service!",
+			"service": "hr-service",
 			"port":    port,
 		})
 	})
@@ -39,12 +38,11 @@ func main() {
 	// Root endpoint
 	r.GET("/", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"message": "Financial Management Service is running",
-			"service": "fm-service",
+			"message": "Human Resources Service is running",
+			"service": "hr-service",
 			"port":    port,
 		})
 	})
 
 	// Start server
-	r.Run(":" + port)
-}
+	r.Run(":" + port)}

--- a/services/m-service/cmd/main.go
+++ b/services/m-service/cmd/main.go
@@ -5,14 +5,13 @@ import (
 	"os"
 
 	"github.com/gin-gonic/gin"
-	"m-service/utils" // Assuming utils package is in the same directory structure
 )
 
 func main() {
 	// Get port from environment or use default
 	port := os.Getenv("PORT")
 	if port == "" {
-		port = "8001"
+		port = "8004"
 	}
 
 	// Create Gin router
@@ -21,17 +20,17 @@ func main() {
 	// Health check endpoint
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"service": "fm-service",
+			"service": "m-service",
 			"status":  "healthy",
 			"port":    port,
 		})
 	})
 
 	// Hello World endpoint
-	r.GET("/api/fm/hello", func(c *gin.Context) {
+	r.GET("/api/manufacturing/hello", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"message": "Hello World from Financial Management Service!",
-			"service": "fm-service",
+			"message": "Hello World from Manufacturing Service!",
+			"service": "m-service",
 			"port":    port,
 		})
 	})
@@ -39,12 +38,11 @@ func main() {
 	// Root endpoint
 	r.GET("/", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"message": "Financial Management Service is running",
-			"service": "fm-service",
+			"message": "Manufacturing Service is running",
+			"service": "m-service",
 			"port":    port,
 		})
 	})
 
 	// Start server
-	r.Run(":" + port)
-}
+	r.Run(":" + port)}

--- a/services/pm-service/cmd/main.go
+++ b/services/pm-service/cmd/main.go
@@ -5,14 +5,13 @@ import (
 	"os"
 
 	"github.com/gin-gonic/gin"
-	"pm-service/utils" // Assuming utils package is in the same directory structure
 )
 
 func main() {
 	// Get port from environment or use default
 	port := os.Getenv("PORT")
 	if port == "" {
-		port = "8001"
+		port = "8005"
 	}
 
 	// Create Gin router
@@ -21,17 +20,17 @@ func main() {
 	// Health check endpoint
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"service": "fm-service",
+			"service": "pm-service",
 			"status":  "healthy",
 			"port":    port,
 		})
 	})
 
 	// Hello World endpoint
-	r.GET("/api/fm/hello", func(c *gin.Context) {
+	r.GET("/api/projects/hello", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"message": "Hello World from Financial Management Service!",
-			"service": "fm-service",
+			"message": "Hello World from Project Management Service!",
+			"service": "pm-service",
 			"port":    port,
 		})
 	})
@@ -39,12 +38,11 @@ func main() {
 	// Root endpoint
 	r.GET("/", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"message": "Financial Management Service is running",
-			"service": "fm-service",
+			"message": "Project Management Service is running",
+			"service": "pm-service",
 			"port":    port,
 		})
 	})
 
 	// Start server
-	r.Run(":" + port)
-}
+	r.Run(":" + port)}

--- a/services/scm-service/cmd/main.go
+++ b/services/scm-service/cmd/main.go
@@ -5,14 +5,13 @@ import (
 	"os"
 
 	"github.com/gin-gonic/gin"
-	"scm-service/utils" // Assuming utils package is in the same directory structure
 )
 
 func main() {
 	// Get port from environment or use default
 	port := os.Getenv("PORT")
 	if port == "" {
-		port = "8001"
+		port = "8006"
 	}
 
 	// Create Gin router
@@ -21,17 +20,17 @@ func main() {
 	// Health check endpoint
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"service": "fm-service",
+			"service": "scm-service",
 			"status":  "healthy",
 			"port":    port,
 		})
 	})
 
 	// Hello World endpoint
-	r.GET("/api/fm/hello", func(c *gin.Context) {
+	r.GET("/api/scm/hello", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"message": "Hello World from Financial Management Service!",
-			"service": "fm-service",
+			"message": "Hello World from Supply Chain Management Service!",
+			"service": "scm-service",
 			"port":    port,
 		})
 	})
@@ -39,12 +38,11 @@ func main() {
 	// Root endpoint
 	r.GET("/", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"message": "Financial Management Service is running",
-			"service": "fm-service",
+			"message": "Supply Chain Management Service is running",
+			"service": "scm-service",
 			"port":    port,
 		})
 	})
 
 	// Start server
-	r.Run(":" + port)
-}
+	r.Run(":" + port)}


### PR DESCRIPTION
## Summary
- correct service names and default ports across CRM, HR, Manufacturing, PM and SCM services

## Testing
- `go vet ./...` *(fails: github.com/gin-gonic/gin download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686ec2df060c8327bd2a748d8e870daf